### PR TITLE
[bugfix] Remove display of 'cat: /sys/class/net/XX/speed: Invalid argument'

### DIFF
--- a/netbw
+++ b/netbw
@@ -25,7 +25,7 @@ function _netbw_get_percent_bar(){
 
 function _netbw_once(){
   iface=$1
-  speed=$(cat /sys/class/net/${iface}/speed) 2>/dev/null 
+  speed=$(cat /sys/class/net/${iface}/speed 2>/dev/null)
   if [ -z "${speed}" ]; then
     speed=1000
   fi


### PR DESCRIPTION
When speed is unavailable, remove the display of 'cat: /sys/class/net/XX/speed: Invalid argument'
